### PR TITLE
Updated to not override images

### DIFF
--- a/Contacts/ABPerson.swift
+++ b/Contacts/ABPerson.swift
@@ -11,15 +11,15 @@ import AddressBook
 
 extension ABPerson {
     func firstName() -> String {
-        return self.valueForProperty(kABFirstNameProperty) as String? ?? ""
+        return self.valueForProperty(kABFirstNameProperty) as! String? ?? ""
     }
 
     func lastName() -> String {
-        return self.valueForProperty(kABLastNameProperty) as String? ?? ""
+        return self.valueForProperty(kABLastNameProperty) as! String? ?? ""
     }
 
     func emails() -> ABMultiValue? {
-        return self.valueForProperty(kABEmailProperty) as ABMultiValue?
+        return self.valueForProperty(kABEmailProperty) as! ABMultiValue?
     }
 
     func setImageDataFromURL(optionalURL: NSURL?) {

--- a/Contacts/ABPerson.swift
+++ b/Contacts/ABPerson.swift
@@ -22,12 +22,4 @@ extension ABPerson {
         return self.valueForProperty(kABEmailProperty) as! ABMultiValue?
     }
 
-    func setImageDataFromURL(optionalURL: NSURL?) {
-        if let url = optionalURL {
-            let data = NSData(contentsOfURL: url)
-            if data != nil {
-                self.setImageData(data)
-            }
-        }
-    }
 }

--- a/Contacts/String.swift
+++ b/Contacts/String.swift
@@ -24,6 +24,6 @@ extension String {
         
         result.destroy()
         
-        return String(format: hash)
+        return String(format: hash as String)
     }
 }

--- a/Contacts/String.swift
+++ b/Contacts/String.swift
@@ -17,7 +17,7 @@ extension String {
         
         CC_MD5(str!, strLen, result)
         
-        var hash = NSMutableString()
+        let hash = NSMutableString()
         for i in 0..<digestLen {
             hash.appendFormat("%02x", result[i])
         }

--- a/Contacts/main.swift
+++ b/Contacts/main.swift
@@ -14,10 +14,10 @@ let people = addressbook.people() as! [ABPerson]
 
 for person in people {
     if let emails = person.emails() {
-        println("Finding Gravatar for \(person.firstName()) \(person.lastName())...")
+        print("Finding Gravatar for \(person.firstName()) \(person.lastName())...")
         
         for i in 0..<emails.count() {
-            let email = Email(address: emails.valueAtIndex(i) as String)
+            let email = Email(address: emails.valueAtIndex(i) as! String)
             
             person.setImageDataFromURL(email.gravatarURL())
         }

--- a/Contacts/main.swift
+++ b/Contacts/main.swift
@@ -11,15 +11,43 @@ import AddressBook
 
 let addressbook = ABAddressBook()
 let people = addressbook.people() as! [ABPerson]
+let group = dispatch_group_create()
+let queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
 
 for person in people {
-    if let emails = person.emails() {
-        print("Finding Gravatar for \(person.firstName()) \(person.lastName())...")
-        
-        for i in 0..<emails.count() {
-            let email = Email(address: emails.valueAtIndex(i) as! String)
+    if person.imageData() == nil {
+        if let emails = person.emails() {
+            print("Finding Gravatar for \(person.firstName()) \(person.lastName())...")
             
-            person.setImageDataFromURL(email.gravatarURL())
+            for i in 0..<emails.count() {
+                let email = Email(address: emails.valueAtIndex(i) as! String)
+                var urlSession : NSURLSession!
+                let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
+                configuration.requestCachePolicy = NSURLRequestCachePolicy.ReloadIgnoringLocalCacheData
+                urlSession = NSURLSession(configuration: configuration)
+                
+                var task = urlSession.dataTaskWithURL(email.gravatarURL()!) {
+                    data, response, error in
+                    let statusCode = (response as? NSHTTPURLResponse)?.statusCode ?? -1
+                    if statusCode == 200 {
+                        print("Found valid Gravatar for \(email.address)")
+                        person.setImageData(data)
+                    }
+                    dispatch_group_leave(group)
+                }
+                dispatch_group_enter(group)
+                task.resume()
+            }
         }
     }
+}
+
+dispatch_group_notify(group, queue) {
+    sleep(5) // allow for setImageData to complete
+    print("All task completed.")
+    exit(0)
+}
+    
+while true {
+    sleep(1)
 }

--- a/Contacts/main.swift
+++ b/Contacts/main.swift
@@ -10,7 +10,7 @@ import Foundation
 import AddressBook
 
 let addressbook = ABAddressBook()
-let people = addressbook.people() as [ABPerson]
+let people = addressbook.people() as! [ABPerson]
 
 for person in people {
     if let emails = person.emails() {

--- a/Gravatar2Contacts.xcodeproj/project.pbxproj
+++ b/Gravatar2Contacts.xcodeproj/project.pbxproj
@@ -115,6 +115,8 @@
 		5C2C4E6A19FC86310049C01A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0710;
+				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "Chad Pytel";
 				TargetAttributes = {

--- a/Gravatar2Contacts.xcodeproj/project.pbxproj
+++ b/Gravatar2Contacts.xcodeproj/project.pbxproj
@@ -117,7 +117,7 @@
 			attributes = {
 				LastSwiftMigration = 0710;
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Chad Pytel";
 				TargetAttributes = {
 					5C2C4E7119FC86310049C01A = {
@@ -176,6 +176,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;

--- a/README.md
+++ b/README.md
@@ -10,14 +10,8 @@ the email address for the contact.
 
 To run it, open the project in XCode and Run.
 
+The program will only query Gravatars for contacts without image. As a result, already set images (manual or previous runs) will be kept.
 If no Gravatar is found for a contact it does not change the image.
-
-However, if any Gravatar is found for a contact, it will replace the existing
-image. In other words, we always use the latest image from Gravatar.
-
-This has the side effect that if you change an image for a contact, run this
-program, and they have a different Gravatar, your custom image will be
-overwritten.
 
 ### Known Issues
 


### PR DESCRIPTION
I've changed the behaviour to only look for Gravatars for contacts without image. This way, custom set images or previous runs are kept.

In the process, I updated to Swift 2.1, Xcode 7.1.1. 
Also made the whole thing run asynchronously and wait for proper termination of URL requests.
